### PR TITLE
Use form encoding for reverse routing

### DIFF
--- a/src/polaris/core.clj
+++ b/src/polaris/core.clj
@@ -161,9 +161,9 @@
 (defn query-item
   [[k v]] 
   (str 
-   (codec/url-encode (name k))
+   (codec/form-encode (name k))
    "="
-   (codec/url-encode v)))
+   (codec/form-encode v)))
 
 (defn build-query-string
   [params query-keys]

--- a/test/polaris/core_test.clj
+++ b/test/polaris/core_test.clj
@@ -1,7 +1,8 @@
 (ns polaris.core-test
   (:require
    [clojure.test :refer :all]
-   [polaris.core :refer :all]))
+   [polaris.core :refer :all])
+  (:import [java.net URLDecoder]))
 
 (defn home
   [request]
@@ -88,7 +89,8 @@
     (is (= "What are you doing out here wasteland?" (:body (handler {:uri "/wasteland"}))))
     (is (= 404 (:status (handler {:uri "/wasteland/further/nothing/here/monolith"}))))
     (is (= "/parallel/perpendicular/line/impossible" (reverse-route routes :perpendicular {:tensor "line" :manifold "impossible"})))
-    (is (= "/parallel/perpendicular/line/impossible?bar=yellow" (reverse-route routes :perpendicular {:tensor "line" :manifold "impossible" :bar "yellow"})))))
+    (is (= "/parallel/perpendicular/line/impossible?bar=yellow" (reverse-route routes :perpendicular {:tensor "line" :manifold "impossible" :bar "yellow"})))
+    (is (= "/child?qp=with+plus" (URLDecoder/decode(reverse-route routes :child {:qp "with+plus"}))))))
 
 (defn ocean-rock
   [request]


### PR DESCRIPTION
Some special characters, like `+` won't work when using the non-form-specific `url-encode` for reversing routes. This PR swaps in `form-encode` from ring-codec, which handles such special characters correctly.  Also includes a `reverse-route` test which verifies that `+`s can be included in query parameters safely after this change.